### PR TITLE
Add Features page to select BMU firmware and adjust SOC accordingly

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,7 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- MG ZS EV: Add new features page to select car's BMS firmware release to adjust SOC display.
 - New vehicle: Maxus eDeliver 3 via OBD-II Port (MEDS)
 - Vehicle: emit standard events on changing v.c.timermode
   New events:

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -162,10 +162,29 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
             break;
         case batterySoCPid:
             {
-                auto soc = value / 10.0;
+                // Get selection from features page
+                bool updatedbmu = MyConfig.GetParamValueBool("xmg", "updatedbmu", true);
+                float scaledSoc;
+                int lowerlimit;
+                int upperlimit;
+                // Get raw value to display on Charging Metrics Page
+                m_soc_raw->SetValue(value / 10);
+                // Setup upper and lower limits
+                if (updatedbmu)
+                {
+                    //New BMU firmware DoD range 40 - 940
+                    lowerlimit = 40;
+                    upperlimit = 940;
+                } else {
+                    //Original BMU firmware DoD range 60 - 970
+                    lowerlimit = 60;
+                    upperlimit = 970;
+                }
+                // Calculate SOC from upper and lower limits
+                scaledSoc = (value - lowerlimit) * 100 / (upperlimit - lowerlimit);
                 if (StandardMetrics.ms_v_charge_inprogress->AsBool())
                 {
-                    if (soc < 96.5)
+                    if (scaledSoc < 99.5)
                     {
                         StandardMetrics.ms_v_charge_state->SetValue("charging");
                     }
@@ -175,12 +194,10 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
                     }
                 }
                 
-                // DoD is approx 6% - 97%, so we need to scale it
-                auto scaledSoc = ((soc * 106.0) / 97.0) - 6.0;
+                // Save SOC for display
                 StandardMetrics.ms_v_bat_soc->SetValue(scaledSoc);
                 // Ideal range set to SoC percentage of 262 km (WLTP Range)
                 StandardMetrics.ms_v_bat_range_ideal->SetValue(262 * (scaledSoc / 100));
-                m_soc_raw->SetValue(soc);
             }
             break;
         case bmsStatusPid:

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -163,7 +163,7 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
         case batterySoCPid:
             {
                 // Get raw value to display on Charging Metrics Page
-                m_soc_raw->SetValue(value / 10);
+                m_soc_raw->SetValue(value / 10.0f);
                 auto scaledSoc = calculateSoc(value);
                 if (StandardMetrics.ms_v_charge_inprogress->AsBool())
                 {
@@ -249,5 +249,5 @@ float OvmsVehicleMgEv::calculateSoc(uint16_t value)
         upperlimit = 970;
     }
     // Calculate SOC from upper and lower limits
-    return (value - lowerlimit) * 100 / (upperlimit - lowerlimit);
+    return (value - lowerlimit) * 100.0f / (upperlimit - lowerlimit);
 }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -162,26 +162,9 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
             break;
         case batterySoCPid:
             {
-                // Get selection from features page
-                bool updatedbmu = MyConfig.GetParamValueBool("xmg", "updatedbmu", true);
-                float scaledSoc;
-                int lowerlimit;
-                int upperlimit;
                 // Get raw value to display on Charging Metrics Page
                 m_soc_raw->SetValue(value / 10);
-                // Setup upper and lower limits
-                if (updatedbmu)
-                {
-                    //New BMU firmware DoD range 40 - 940
-                    lowerlimit = 40;
-                    upperlimit = 940;
-                } else {
-                    //Original BMU firmware DoD range 60 - 970
-                    lowerlimit = 60;
-                    upperlimit = 970;
-                }
-                // Calculate SOC from upper and lower limits
-                scaledSoc = (value - lowerlimit) * 100 / (upperlimit - lowerlimit);
+                auto scaledSoc = calculateSoc(value);
                 if (StandardMetrics.ms_v_charge_inprogress->AsBool())
                 {
                     if (scaledSoc < 99.5)
@@ -245,4 +228,26 @@ void OvmsVehicleMgEv::SetBmsStatus(uint8_t status)
             } 
             break;
     }
+}
+
+float OvmsVehicleMgEv::calculateSoc(uint16_t value)
+{
+    int lowerlimit;
+    int upperlimit;
+    
+    // Setup upper and lower limits from selection on features page
+    if (MyConfig.GetParamValueBool("xmg", "updatedbmu", true))
+    {
+        //New BMU firmware DoD range 40 - 940
+        lowerlimit = 40;
+        upperlimit = 940;
+    }
+    else
+    {
+        //Original BMU firmware DoD range 60 - 970
+        lowerlimit = 60;
+        upperlimit = 970;
+    }
+    // Calculate SOC from upper and lower limits
+    return (value - lowerlimit) * 100 / (upperlimit - lowerlimit);
 }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_web.cpp
@@ -65,9 +65,64 @@ using namespace std;
 void OvmsVehicleMgEv::WebInit()
 {
     // vehicle menu:
+    MyWebServer.RegisterPage("/xmg/features", "Features", WebCfgFeatures, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xmg/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xmg/metrics_charger", "Charging Metrics", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
+}
+
+/**
+ * WebDeInit: deregister pages
+ */
+void OvmsVehicleMgEv::WebDeInit()
+{
+  MyWebServer.DeregisterPage("/xmg/features");
+  MyWebServer.DeregisterPage("/xmg/metrics_charger");
+  MyWebServer.DeregisterPage("/xmg/battmon");
+}
+
+/**
+ * WebCfgFeatures: configure general parameters (URL /xmg/config)
+ */
+void OvmsVehicleMgEv::WebCfgFeatures(PageEntry_t &p, PageContext_t &c)
+{
+    std::string error;
+    bool updatedbmu;
     
-    MyWebServer.RegisterPage("/bms/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
-    MyWebServer.RegisterPage("/bms/metrics_charger", "Charging Metrics", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
+    if (c.method == "POST") {
+        updatedbmu = (c.getvar("updatedbmu") == "yes");
+        
+        if (error == "") {
+          // store:
+          MyConfig.SetParamValueBool("xmg", "updatedbmu", updatedbmu);
+          
+          c.head(200);
+          c.alert("success", "<p class=\"lead\">MG ZS EV / MG5 feature configuration saved.</p>");
+          MyWebServer.OutputHome(p, c);
+          c.done();
+          return;
+        }
+        // output error, return to form:
+        error = "<p class=\"lead\">Error!</p><ul class=\"errorlist\">" + error + "</ul>";
+        c.head(400);
+        c.alert("danger", error.c_str());
+    } else {
+        // read configuration:
+        updatedbmu = MyConfig.GetParamValueBool("xmg", "updatedbmu", false);
+        c.head(200);
+    }
+    // generate form:
+    c.panel_start("primary", "MG ZS EV / MG5 ffeature configuration");
+    c.form_start(p.uri);
+
+    c.fieldset_start("General");
+    c.input_checkbox("Updated BMU Firmware", "updatedbmu", updatedbmu,
+      "<p>Select this if you have BMU Firmware later than Jan 2021</p>");
+    c.fieldset_end();
+    c.print("<hr>");
+    c.input_button("default", "Save");
+    c.form_end();
+    c.panel_end();
+    c.done();
 }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -174,6 +174,10 @@ OvmsVehicleMgEv::~OvmsVehicleMgEv()
     ESP_LOGI(TAG, "Shutdown MG EV vehicle module");
 
     //xTimerDelete(m_zombieTimer, 0);
+    
+    #ifdef CONFIG_OVMS_COMP_WEBSERVER
+        WebDeInit();
+    #endif
 
     if (m_cmdSoftver)
     {

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -172,13 +172,13 @@ OvmsVehicleMgEv::OvmsVehicleMgEv()
 OvmsVehicleMgEv::~OvmsVehicleMgEv()
 {
     ESP_LOGI(TAG, "Shutdown MG EV vehicle module");
-
+    
     //xTimerDelete(m_zombieTimer, 0);
     
-    #ifdef CONFIG_OVMS_COMP_WEBSERVER
-        WebDeInit();
-    #endif
-
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+    WebDeInit();
+#endif
+    
     if (m_cmdSoftver)
     {
         MyCommandApp.UnregisterCommand(m_cmdSoftver->GetName());

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
@@ -176,7 +176,8 @@ class OvmsVehicleMgEv : public OvmsVehicle
     //
   public:
     void WebInit();
-    //static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
+    void WebDeInit();
+    static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     void GetDashboardConfig(DashboardConfig& cfg);
     static void WebDispChgMetrics(PageEntry_t &p, PageContext_t &c);
 #endif //CONFIG_OVMS_COMP_WEBSERVER

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
@@ -87,6 +87,7 @@ class OvmsVehicleMgEv : public OvmsVehicle
     static void WakeUp(void* self);
     
     void processEnergy();
+    float calculateSoc(uint16_t value);
 
     void IncomingPollFrame(CAN_frame_t* frame);
     bool SendPollMessage(canbus* bus, uint16_t id, uint8_t type, uint16_t pid);


### PR DESCRIPTION
Have added a new page under MG tab called features. This allows users to indicate if they have the January BMS update installed. If selected, the SOC calculation is adjusted accordingly. I have changed the formula slightly as well.