### PR TITLE
Add new selection on features page for UK Vehicles to correct Estimated Range error.

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,7 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- MG ZS EV: Add new selection on features page for UK Vehicles to correct Estimated Range error.
 - MG ZS EV: Add new features page to select car's BMS firmware release to adjust SOC display.
 - New vehicle: Maxus eDeliver 3 via OBD-II Port (MED3)
   https://docs.openvehicles.com/en/latest/components/vehicle_maxus_edeliver3/docs/index.html

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -194,7 +194,15 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
             StandardMetrics.ms_v_bat_soh->SetValue(value / 100.0);
             break;
         case bmsRangePid:
-            StandardMetrics.ms_v_bat_range_est->SetValue(value / 10.0);
+            // Need to adjust for New BMS on English Vehicles
+            if (MyConfig.GetParamValueBool("xmg", "ukvehicle", true))
+            {
+                StandardMetrics.ms_v_bat_range_est->SetValue(value);
+            }
+            else
+            {
+                StandardMetrics.ms_v_bat_range_est->SetValue(value / 10.0);
+            }
             break;
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -179,8 +179,9 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
                 
                 // Save SOC for display
                 StandardMetrics.ms_v_bat_soc->SetValue(scaledSoc);
-                // Ideal range set to SoC percentage of 262 km (WLTP Range)
-                StandardMetrics.ms_v_bat_range_ideal->SetValue(262 * (scaledSoc / 100));
+                // Estimated range set to Ideal Range reduced for HVAC usage
+                StandardMetrics.ms_v_bat_range_est->SetValue(
+                        StandardMetrics.ms_v_bat_range_ideal->AsFloat() / 1.08);
             }
             break;
         case bmsStatusPid:
@@ -197,11 +198,11 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
             // Need to adjust for New BMS on English Vehicles
             if (MyConfig.GetParamValueBool("xmg", "ukvehicle", true))
             {
-                StandardMetrics.ms_v_bat_range_est->SetValue(value);
+                StandardMetrics.ms_v_bat_range_ideal->SetValue(value);
             }
             else
             {
-                StandardMetrics.ms_v_bat_range_est->SetValue(value / 10.0);
+                StandardMetrics.ms_v_bat_range_ideal->SetValue(value / 10.0);
             }
             break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_web.cpp
@@ -87,14 +87,17 @@ void OvmsVehicleMgEv::WebCfgFeatures(PageEntry_t &p, PageContext_t &c)
 {
     std::string error;
     bool updatedbmu;
-    
+    bool ukvehicle;
+
     if (c.method == "POST") {
         updatedbmu = (c.getvar("updatedbmu") == "yes");
-        
+        ukvehicle = (c.getvar("ukvehicle") == "yes");
+
         if (error == "") {
           // store:
-          MyConfig.SetParamValueBool("xmg", "updatedbmu", updatedbmu);
-          
+            MyConfig.SetParamValueBool("xmg", "updatedbmu", updatedbmu);
+            MyConfig.SetParamValueBool("xmg", "ukvehicle", ukvehicle);
+
           c.head(200);
           c.alert("success", "<p class=\"lead\">MG ZS EV / MG5 feature configuration saved.</p>");
           MyWebServer.OutputHome(p, c);
@@ -108,6 +111,7 @@ void OvmsVehicleMgEv::WebCfgFeatures(PageEntry_t &p, PageContext_t &c)
     } else {
         // read configuration:
         updatedbmu = MyConfig.GetParamValueBool("xmg", "updatedbmu", false);
+        ukvehicle = MyConfig.GetParamValueBool("xmg", "ukvehicle", false);
         c.head(200);
     }
     // generate form:
@@ -117,6 +121,8 @@ void OvmsVehicleMgEv::WebCfgFeatures(PageEntry_t &p, PageContext_t &c)
     c.fieldset_start("General");
     c.input_checkbox("Updated BMU Firmware", "updatedbmu", updatedbmu,
       "<p>Select this if you have BMU Firmware later than Jan 2021</p>");
+    c.input_checkbox("British Vehicle", "ukvehicle", ukvehicle,
+      "<p>Select this if you have selected the above and vehicle is in the UK</p>");
     c.fieldset_end();
     c.print("<hr>");
     c.input_button("default", "Save");


### PR DESCRIPTION
UK vehicles with the new BMS are experiencing incorrect Estimated Range because of changes made in this update.
I have added another selection to the features which when selected will fix the error.
Have changed Ideal Range to the value returned by the vehicle and estimated to ideal / 1.08 to adjust for HVAC